### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Notification/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Notification/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Notifications Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Notification/Class/Notification/Handler/Decorator/AlarmTest.php
+++ b/test/Horde/Notification/Class/Notification/Handler/Decorator/AlarmTest.php
@@ -25,7 +25,7 @@
 class Horde_Notification_Class_Notification_Handler_Decorator_AlarmTest
 extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->markTestIncomplete('Currently broken');
         if (!class_exists('Horde_Alarm')) {

--- a/test/Horde/Notification/Class/Notification/Handler/Decorator/LogTest.php
+++ b/test/Horde/Notification/Class/Notification/Handler/Decorator/LogTest.php
@@ -25,13 +25,13 @@
 class Horde_Notification_Class_Notification_Handler_Decorator_LogTest
 extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (!class_exists('Horde_Log_Logger')) {
             $this->markTestSkipped('The Horde_Log package is not installed!');
         }
 
-        $this->logger = $this->getMock('Horde_Log_Logger');
+        $this->logger = $this->getMockBuilder('Horde_Log_Logger')->getMock();
         $this->log = new Horde_Notification_Handler_Decorator_Log(
             $this->logger
         );

--- a/test/Horde/Notification/Class/Notification/Handler/Decorator/LogTest.php
+++ b/test/Horde/Notification/Class/Notification/Handler/Decorator/LogTest.php
@@ -22,6 +22,7 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 
+#[\AllowDynamicProperties]
 class Horde_Notification_Class_Notification_Handler_Decorator_LogTest
 extends Horde_Test_Case
 {

--- a/test/Horde/Notification/Class/Notification/HandlerTest.php
+++ b/test/Horde/Notification/Class/Notification/HandlerTest.php
@@ -21,7 +21,7 @@
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
-
+#[\AllowDynamicProperties]
 class Horde_Notification_Class_Notification_HandlerTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/Notification/Class/Notification/HandlerTest.php
+++ b/test/Horde/Notification/Class/Notification/HandlerTest.php
@@ -24,13 +24,13 @@
 
 class Horde_Notification_Class_Notification_HandlerTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->storage = new Horde_Notification_Storage_Session('test');
         $this->handler = new Horde_Notification_Handler($this->storage);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($_SESSION);
     }
@@ -106,7 +106,7 @@ class Horde_Notification_Class_Notification_HandlerTest extends Horde_Test_Case
 
     public function testMethodClearHasPostconditionThatTheStorageOfTheSpecifiedListenerWasCleared()
     {
-        $storage = $this->getMock('Horde_Notification_Storage_Interface');
+        $storage = $this->getMockBuilder('Horde_Notification_Storage_Interface')->getMock();
         $storage->expects($this->once())
             ->method('clear')
             ->with('dummy');
@@ -117,7 +117,7 @@ class Horde_Notification_Class_Notification_HandlerTest extends Horde_Test_Case
 
     public function testMethodClearHasPostconditionThatAllUnattachedEventsHaveBeenClearedFromStorageIfNoListenerWasSpecified()
     {
-        $storage = $this->getMock('Horde_Notification_Storage_Interface');
+        $storage = $this->getMockBuilder('Horde_Notification_Storage_Interface')->getMock();
         $storage->expects($this->once())
             ->method('clear')
             ->with('_unattached');
@@ -139,7 +139,7 @@ class Horde_Notification_Class_Notification_HandlerTest extends Horde_Test_Case
 
     public function testMethodAdddecoratorHasPostconditionThatTheGivenDecoratorWasAddedToTheHandlerAndReceivesPushCalls()
     {
-        $decorator = $this->getMock('Horde_Notification_Handler_Decorator_Base');
+        $decorator = $this->getMockBuilder('Horde_Notification_Handler_Decorator_Base')->getMock();
         $decorator->expects($this->once())
             ->method('push')
             ->with($this->isInstanceOf('Horde_Notification_Event'));
@@ -151,7 +151,7 @@ class Horde_Notification_Class_Notification_HandlerTest extends Horde_Test_Case
 
     public function testMethodAdddecoratorHasPostconditionThatTheGivenDecoratorWasAddedToTheHandlerAndReceivesNotifyCalls()
     {
-        $decorator = $this->getMock('Horde_Notification_Handler_Decorator_Base');
+        $decorator = $this->getMockBuilder('Horde_Notification_Handler_Decorator_Base')->getMock();
         $decorator->expects($this->once())
             ->method('notify');
         $this->handler->attach('audio');

--- a/test/Horde/Notification/Class/Notification/Listener/StatusTest.php
+++ b/test/Horde/Notification/Class/Notification/Listener/StatusTest.php
@@ -37,6 +37,7 @@ class Horde_Notification_Class_Notification_Listener_StatusTest extends Horde_Te
 
     public function testMethodNotifyHasNoOutputIfTheMessageStackIsEmpty()
     {
+        $this->expectNotToPerformAssertions();
         $listener = new Horde_Notification_Listener_Status();
         $messages = array();
         $listener->notify($messages);

--- a/test/Horde/Notification/Class/Notification/ListenerTest.php
+++ b/test/Horde/Notification/Class/Notification/ListenerTest.php
@@ -23,7 +23,7 @@
  */
 class Horde_Notification_Class_Notification_ListenerTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (!class_exists('PEAR_Error')) {
             $this->markTestSkipped('The PEAR_Error class is not available!');

--- a/test/Horde/Notification/Class/NotificationTest.php
+++ b/test/Horde/Notification/Class/NotificationTest.php
@@ -24,7 +24,7 @@
 
 class Horde_Notification_Class_NotificationTest extends Horde_Test_Case
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($_SESSION);
     }


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-notification/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Fix PHP 8.2 deprecation warnings. https://salsa.debian.org/horde-team/php-horde-notification/-/blob/debian-sid/debian/patches/1012_php8.2.patch
